### PR TITLE
[Build][Gen] Compiled Acceleo Files Fix

### DIFF
--- a/go/ecore/eclass_impl.go
+++ b/go/ecore/eclass_impl.go
@@ -77,14 +77,14 @@ func (eClass *eClassImpl) GetEOperation(int) EOperation {
 	panic("GetEOperation not implemented")
 }
 
-// GetEStructuralFeatureFromString default implementation
-func (eClass *eClassImpl) GetEStructuralFeatureFromString(string) EStructuralFeature {
-	panic("GetEStructuralFeatureFromString not implemented")
-}
-
 // GetEStructuralFeature default implementation
 func (eClass *eClassImpl) GetEStructuralFeature(int) EStructuralFeature {
 	panic("GetEStructuralFeature not implemented")
+}
+
+// GetEStructuralFeatureFromString default implementation
+func (eClass *eClassImpl) GetEStructuralFeatureFromString(string) EStructuralFeature {
+	panic("GetEStructuralFeatureFromString not implemented")
 }
 
 // GetFeatureCount default implementation
@@ -436,10 +436,10 @@ func (eClass *eClassImpl) EInvokeFromID(operationID int, arguments EList) interf
 	switch operationID {
 	case ECLASS__GET_EOPERATION_EINT:
 		return eClass.GetEOperation(arguments.Get(0).(int))
-	case ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING:
-		return eClass.GetEStructuralFeatureFromString(arguments.Get(0).(string))
 	case ECLASS__GET_ESTRUCTURAL_FEATURE_EINT:
 		return eClass.GetEStructuralFeature(arguments.Get(0).(int))
+	case ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING:
+		return eClass.GetEStructuralFeatureFromString(arguments.Get(0).(string))
 	case ECLASS__GET_FEATURE_COUNT:
 		return eClass.GetFeatureCount()
 	case ECLASS__GET_FEATURE_ID_ESTRUCTURALFEATURE:

--- a/go/ecore/eclass_impl_test.go
+++ b/go/ecore/eclass_impl_test.go
@@ -104,10 +104,10 @@ func TestEClassAbstractEInvoke(t *testing.T) {
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_EOPERATION_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
 	}
 	{
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_FEATURE_COUNT, nil) })
@@ -340,10 +340,10 @@ func TestEClassInterfaceEInvoke(t *testing.T) {
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_EOPERATION_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
 	}
 	{
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_FEATURE_COUNT, nil) })
@@ -566,10 +566,10 @@ func TestEClassEStructuralFeaturesEInvoke(t *testing.T) {
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_EOPERATION_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
 	}
 	{
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_FEATURE_COUNT, nil) })
@@ -792,10 +792,10 @@ func TestEClassEAttributesEInvoke(t *testing.T) {
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_EOPERATION_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
 	}
 	{
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_FEATURE_COUNT, nil) })
@@ -1018,10 +1018,10 @@ func TestEClassEReferencesEInvoke(t *testing.T) {
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_EOPERATION_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
 	}
 	{
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_FEATURE_COUNT, nil) })
@@ -1244,10 +1244,10 @@ func TestEClassESuperTypesEInvoke(t *testing.T) {
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_EOPERATION_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
 	}
 	{
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_FEATURE_COUNT, nil) })
@@ -1470,10 +1470,10 @@ func TestEClassEOperationsEInvoke(t *testing.T) {
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_EOPERATION_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
 	}
 	{
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_FEATURE_COUNT, nil) })
@@ -1696,10 +1696,10 @@ func TestEClassEContainmentsEInvoke(t *testing.T) {
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_EOPERATION_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
 	}
 	{
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_FEATURE_COUNT, nil) })
@@ -1922,10 +1922,10 @@ func TestEClassECrossReferencesEInvoke(t *testing.T) {
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_EOPERATION_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
 	}
 	{
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_FEATURE_COUNT, nil) })
@@ -2148,10 +2148,10 @@ func TestEClassEAllAttributesEInvoke(t *testing.T) {
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_EOPERATION_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
 	}
 	{
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_FEATURE_COUNT, nil) })
@@ -2374,10 +2374,10 @@ func TestEClassEAllReferencesEInvoke(t *testing.T) {
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_EOPERATION_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
 	}
 	{
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_FEATURE_COUNT, nil) })
@@ -2600,10 +2600,10 @@ func TestEClassEAllContainmentsEInvoke(t *testing.T) {
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_EOPERATION_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
 	}
 	{
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_FEATURE_COUNT, nil) })
@@ -2826,10 +2826,10 @@ func TestEClassEAllOperationsEInvoke(t *testing.T) {
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_EOPERATION_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
 	}
 	{
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_FEATURE_COUNT, nil) })
@@ -3052,10 +3052,10 @@ func TestEClassEAllStructuralFeaturesEInvoke(t *testing.T) {
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_EOPERATION_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
 	}
 	{
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_FEATURE_COUNT, nil) })
@@ -3278,10 +3278,10 @@ func TestEClassEAllSuperTypesEInvoke(t *testing.T) {
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_EOPERATION_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
 	}
 	{
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_FEATURE_COUNT, nil) })
@@ -3499,10 +3499,10 @@ func TestEClassEIDAttributeEInvoke(t *testing.T) {
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_EOPERATION_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_EINT, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_ESTRUCTURAL_FEATURE_ESTRING, nil) })
 	}
 	{
 		assert.Panics(t, func() { obj.EInvokeFromID(ECLASS__GET_FEATURE_COUNT, nil) })

--- a/go/ecore/eenum_impl.go
+++ b/go/ecore/eenum_impl.go
@@ -42,14 +42,14 @@ func (eEnum *eEnumImpl) EStaticClass() EClass {
 	return GetPackage().GetEEnum()
 }
 
-// GetEEnumLiteralByName default implementation
-func (eEnum *eEnumImpl) GetEEnumLiteralByName(string) EEnumLiteral {
-	panic("GetEEnumLiteralByName not implemented")
-}
-
 // GetEEnumLiteralByValue default implementation
 func (eEnum *eEnumImpl) GetEEnumLiteralByValue(int) EEnumLiteral {
 	panic("GetEEnumLiteralByValue not implemented")
+}
+
+// GetEEnumLiteralByName default implementation
+func (eEnum *eEnumImpl) GetEEnumLiteralByName(string) EEnumLiteral {
+	panic("GetEEnumLiteralByName not implemented")
 }
 
 // GetEEnumLiteralByLiteral default implementation
@@ -110,10 +110,10 @@ func (eEnum *eEnumImpl) EIsSetFromID(featureID int) bool {
 
 func (eEnum *eEnumImpl) EInvokeFromID(operationID int, arguments EList) interface{} {
 	switch operationID {
-	case EENUM__GET_EENUM_LITERAL_ESTRING:
-		return eEnum.GetEEnumLiteralByName(arguments.Get(0).(string))
 	case EENUM__GET_EENUM_LITERAL_EINT:
 		return eEnum.GetEEnumLiteralByValue(arguments.Get(0).(int))
+	case EENUM__GET_EENUM_LITERAL_ESTRING:
+		return eEnum.GetEEnumLiteralByName(arguments.Get(0).(string))
 	case EENUM__GET_EENUM_LITERAL_BY_LITERAL_ESTRING:
 		return eEnum.GetEEnumLiteralByLiteral(arguments.Get(0).(string))
 	default:

--- a/go/ecore/eenum_impl_test.go
+++ b/go/ecore/eenum_impl_test.go
@@ -46,10 +46,10 @@ func TestEEnumELiteralsEGet(t *testing.T) {
 func TestEEnumELiteralsEInvoke(t *testing.T) {
 	obj := newEEnumImpl()
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(EENUM__GET_EENUM_LITERAL_ESTRING, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(EENUM__GET_EENUM_LITERAL_EINT, nil) })
 	}
 	{
-		assert.Panics(t, func() { obj.EInvokeFromID(EENUM__GET_EENUM_LITERAL_EINT, nil) })
+		assert.Panics(t, func() { obj.EInvokeFromID(EENUM__GET_EENUM_LITERAL_ESTRING, nil) })
 	}
 	{
 		assert.Panics(t, func() { obj.EInvokeFromID(EENUM__GET_EENUM_LITERAL_BY_LITERAL_ESTRING, nil) })

--- a/java/acceleo/src/soft/acceleo/AcceleoURIHandler.java
+++ b/java/acceleo/src/soft/acceleo/AcceleoURIHandler.java
@@ -34,7 +34,24 @@ public class AcceleoURIHandler implements IAcceleoParserURIHandler {
 		if ( Arrays.stream(segments).anyMatch(s -> SEGMENT_EMPTY.equals(s) || SEGMENT_SELF.equals(s) || SEGMENT_PARENT.equals(s) )) {
 			newURI = URI.createHierarchicalURI( uri.scheme(), uri.authority(), uri.device(), resolve(segments), uri.query(), uri.fragment());
 		}
+		newURI = toAcceleoJar( newURI );
 		return newURI;
 	}
 
+	
+	private URI toAcceleoJar( URI uri ) {
+		String uriStr = uri.toString();
+		if (uriStr.startsWith("jar:file:")) {
+			int indexOf = uriStr.indexOf(".jar!/");
+			if (indexOf != -1) {
+				String name = uriStr;
+				name = name.substring(0, indexOf);
+				name = name.substring( name.lastIndexOf('/') + 1);
+				name = "acceleo-jar:" + name + ".jar!/" + uriStr.substring(indexOf + ".jar!/".length());
+				uri = URI.createURI(name);
+			}
+		}
+		return uri;
+	}
+	
 }

--- a/java/acceleo/src/soft/acceleo/AcceleoURIHandler.java
+++ b/java/acceleo/src/soft/acceleo/AcceleoURIHandler.java
@@ -34,24 +34,23 @@ public class AcceleoURIHandler implements IAcceleoParserURIHandler {
 		if ( Arrays.stream(segments).anyMatch(s -> SEGMENT_EMPTY.equals(s) || SEGMENT_SELF.equals(s) || SEGMENT_PARENT.equals(s) )) {
 			newURI = URI.createHierarchicalURI( uri.scheme(), uri.authority(), uri.device(), resolve(segments), uri.query(), uri.fragment());
 		}
-		newURI = toAcceleoJar( newURI );
+		newURI = toClasspath( newURI );
 		return newURI;
 	}
-
 	
-	private URI toAcceleoJar( URI uri ) {
+	private URI toClasspath( URI uri ) {
 		String uriStr = uri.toString();
 		if (uriStr.startsWith("jar:file:")) {
 			int indexOf = uriStr.indexOf(".jar!/");
 			if (indexOf != -1) {
 				String name = uriStr;
-				name = name.substring(0, indexOf);
-				name = name.substring( name.lastIndexOf('/') + 1);
-				name = "acceleo-jar:" + name + ".jar!/" + uriStr.substring(indexOf + ".jar!/".length());
+				name = "classpath:" + name.substring(indexOf + ".jar!".length() );
 				uri = URI.createURI(name);
 			}
 		}
 		return uri;
 	}
+	
+	
 	
 }

--- a/java/generators/soft.generator.common/src/soft/generator/common/Generator.java
+++ b/java/generators/soft.generator.common/src/soft/generator/common/Generator.java
@@ -2,6 +2,7 @@ package soft.generator.common;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -9,6 +10,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -20,14 +22,24 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.eclipse.acceleo.common.IAcceleoConstants;
+import org.eclipse.acceleo.common.internal.utils.AcceleoPackageRegistry;
+import org.eclipse.acceleo.common.utils.ModelUtils;
 import org.eclipse.acceleo.engine.event.AcceleoTextGenerationEvent;
 import org.eclipse.acceleo.engine.event.IAcceleoTextGenerationListener;
 import org.eclipse.acceleo.engine.service.AbstractAcceleoGenerator;
 import org.eclipse.acceleo.engine.service.AcceleoService;
+import org.eclipse.acceleo.model.mtl.Module;
+import org.eclipse.acceleo.model.mtl.resource.AcceleoResourceFactoryRegistry;
+import org.eclipse.acceleo.model.mtl.resource.AcceleoResourceSetImpl;
 import org.eclipse.emf.common.util.BasicMonitor;
 import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.plugin.EcorePlugin;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.Resource.Factory;
 import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.URIConverter;
+import org.eclipse.emf.ecore.resource.impl.ExtensibleURIConverterImpl;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -36,6 +48,20 @@ import com.google.common.collect.Maps;
  * Entry point of the 'Generate' generation module.
  */
 public class Generator extends AbstractAcceleoGenerator {
+
+    private class ResourceFactoryRegistry extends AcceleoResourceFactoryRegistry {
+        public ResourceFactoryRegistry(Resource.Factory.Registry delegate) {
+            super(delegate);
+        }
+
+        protected Factory delegatedGetFactory(URI uri, String contentTypeIdentifier) {
+            if ("classpath".equals(uri.scheme())) {
+                URL url = getClass().getResource(uri.path());
+                uri = createTemplateURI(url.toString());
+            }
+            return super.delegatedGetFactory(uri, contentTypeIdentifier);
+        }
+    }
 
     /**
      * The list of properties files from the launch parameters (Launch
@@ -68,17 +94,8 @@ public class Generator extends AbstractAcceleoGenerator {
      * @generated
      */
     private Generator(URI modelURI, File targetFolder, List<? extends Object> arguments) throws IOException {
-        initialize(modelURI, targetFolder, arguments);
-    }
-
-    public void initialize(URI modelURI, File targetFolder, List<? extends Object> arguments) throws IOException {
         initializeArguments(arguments);
-        super.initialize(modelURI, targetFolder, Collections.emptyList());
-    }
-
-    public void initialize(EObject model, File targetFolder, List<? extends Object> arguments) throws IOException {
-        initializeArguments(arguments);
-        super.initialize(model, targetFolder, Collections.emptyList());
+        initializeGenerator(modelURI, targetFolder, Collections.emptyList());
     }
 
     private void initializeArguments(List<? extends Object> arguments) {
@@ -90,6 +107,63 @@ public class Generator extends AbstractAcceleoGenerator {
         this.properties = properties;
         Boolean silent = (Boolean) arguments.get(3);
         this.silent = silent;
+    }
+
+    public void initializeGenerator(URI modelURI, File folder, List<? extends Object> arguments) throws IOException {
+        ResourceSet modulesResourceSet = new AcceleoResourceSetImpl();
+        modulesResourceSet.setPackageRegistry(AcceleoPackageRegistry.INSTANCE);
+
+        resourceFactoryRegistry = modulesResourceSet.getResourceFactoryRegistry();
+        modulesResourceSet.setResourceFactoryRegistry(new ResourceFactoryRegistry(resourceFactoryRegistry));
+
+        URIConverter uriConverter = createURIConverter();
+        if (uriConverter != null) {
+            modulesResourceSet.setURIConverter(uriConverter);
+        }
+
+        Map<URI, URI> uriMap = EcorePlugin.computePlatformURIMap(false);
+
+        // make sure that metamodel projects in the workspace override those in plugins
+        modulesResourceSet.getURIConverter().getURIMap().putAll(uriMap);
+
+        registerResourceFactories(modulesResourceSet);
+        registerPackages(modulesResourceSet);
+
+        ResourceSet modelResourceSet = new AcceleoResourceSetImpl();
+        modelResourceSet.setPackageRegistry(AcceleoPackageRegistry.INSTANCE);
+        if (uriConverter != null) {
+            modelResourceSet.setURIConverter(uriConverter);
+        }
+
+        // make sure that metamodel projects in the workspace override those in plugins
+        modelResourceSet.getURIConverter().getURIMap().putAll(uriMap);
+
+        registerResourceFactories(modelResourceSet);
+        registerPackages(modelResourceSet);
+
+        String moduleName = getModuleName();
+        if (moduleName.endsWith('.' + IAcceleoConstants.MTL_FILE_EXTENSION)) {
+            moduleName = moduleName.substring(0, moduleName.lastIndexOf('.'));
+        }
+        if (!moduleName.endsWith('.' + IAcceleoConstants.EMTL_FILE_EXTENSION)) {
+            moduleName += '.' + IAcceleoConstants.EMTL_FILE_EXTENSION;
+        }
+
+        URL moduleURL = findModuleURL(moduleName);
+
+        if (moduleURL == null) {
+            throw new IOException("'" + getModuleName() + ".emtl' not found"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        URI moduleURI = createTemplateURI(moduleURL.toString());
+        moduleURI = URI.createURI(moduleURI.toString(), true);
+        module = (Module) ModelUtils.load(moduleURI, modulesResourceSet);
+
+        URI newModelURI = URI.createURI(modelURI.toString(), true);
+        model = ModelUtils.load(newModelURI, modelResourceSet);
+        targetFolder = folder;
+        generationArguments = arguments;
+
+        this.postInitialize();
     }
 
     protected AcceleoService createAcceleoService() {
@@ -311,6 +385,28 @@ public class Generator extends AbstractAcceleoGenerator {
                        .put(org.eclipse.emf.ecore.EcorePackage.eINSTANCE.getNsURI(),
                             org.eclipse.emf.ecore.EcorePackage.eINSTANCE);
         }
+    }
+
+    protected URIConverter createURIConverter() {
+        return new ExtensibleURIConverterImpl() {
+            /**
+             * {@inheritDoc}
+             * 
+             * @see org.eclipse.emf.ecore.resource.impl.ExtensibleURIConverterImpl#normalize(org.eclipse.emf.common.util.URI)
+             */
+            @Override
+            public URI normalize(URI uri) {
+                URI normalized = getURIMap().get(uri);
+                if (normalized == null) {
+                    if ("classpath".equals(uri.scheme())) {
+                        URL url = getClass().getResource(uri.path());
+                        normalized = createTemplateURI(url.toString());
+                        getURIMap().put(uri, normalized);
+                    }
+                }
+                return normalized != null ? normalized : super.normalize(uri);
+            }
+        };
     }
 
 }


### PR DESCRIPTION
Remove all fullpath references in compiled acceleo files. 

They are replaced with classpath protocol. As jar entries need to be fullpath , they are computed dynamically when used. 